### PR TITLE
fix MAX_BASE_FUNC overflow

### DIFF
--- a/src/include/functions.h
+++ b/src/include/functions.h
@@ -76,7 +76,7 @@ typedef package(*bf_type) (Var, Byte, void *, Objid);
 typedef void (*bf_write_type) (void *vdata);
 typedef void *(*bf_read_type) (void);
 
-#define MAX_BASE_FUNC    256
+#define MAX_BASE_FUNC    255
 #define MAX_FUNC         65535
 #define FUNC_NOT_FOUND   MAX_FUNC
 /* valid base function numbers are 0 - 255, or a total of 256 of them.


### PR DESCRIPTION
MAX_BASE_FUNC overflow causes function 256 (counting from 0) to overflow, creating a call to function 0 (run_gc)

Checking out from master, the function is `char_list()`. Checking `;function_info()[257][1]` should tell you the affected builtin if you're running a modified build.

Before:
```
;char_list("bob")
#-1:Input to EVAL (this == #-1), line 3:  Incorrect number of arguments (expected 0; got 1)
... called from built-in function eval()
... called from #58:eval_cmd_string, line 19
... called from #58:eval*-d, line 13
(End of traceback)
```

After:
```
;char_list("bob")
=> {"b", "o", "b"}
```