### PR TITLE
compilation fix for clang on MacOS

### DIFF
--- a/src/curl.cc
+++ b/src/curl.cc
@@ -3,6 +3,7 @@
 #ifdef CURL_FOUND
 
 #include <curl/curl.h>
+#include <string>
 
 #include "curl.h"
 #include "functions.h"


### PR DESCRIPTION
I needed this change to compile with clang on MacOS. I haven't tested on anything else so caveat emptor.

```
src/curl.cc:127:25: error: implicit instantiation of undefined template 'std::basic_string<char>'
            std::string token = value.v.str;
                        ^
1 error generated.
```